### PR TITLE
Validate pams banks eo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ rsconnect/
 
 # Ignore the `.yml` file
 config.yml
+
+# Ignore .DS_Store
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,25 +1,42 @@
 # workflow.pams.qa
-This repository is meant to allow users to easily produce a `.Rmd` status report that compares two PAMS datasets.
+This repository is meant to allow users to easily produce `.Rmd` status reports that compares two PAMS datasets or validate the consistency between a PAMS data set and a related data set.
 
 
 ## Configuration
 
 Configurations are set in the `config.yml` file. 
 
-Paths must be defined that point to two different PAMS datasets as input (for example `PATH/TO/PAMS_2021Q4` and `PATH/TO/PAMS_2022Q4`). The output will be a `html` report, assessing if various expectations are met, comparing the two datasets. 
+For a comparison of two PAMS datasets over time, paths must be defined that point to two different PAMS datasets as input (for example `PATH/TO/PAMS_2021Q4` and `PATH/TO/PAMS_2022Q4`).
+
+For a consistency check between a PAMS dataset and a Banks Equity Ownership dataset, paths must be defined that point to the relevant datasets as input (for example `PATH/TO/PAMS_2023Q2` and `PATH/TO/BANKS_EO_2023Q2`).
+
+
+The output will be a `html` report, assessing if various expectations are met, comparing the two datasets. 
 
 Threshold values must also be set in the `config.yml` file. 
 
 ``` yaml
 default:
 
-    paths:
-        path_pams_base: /PATH/TO/BASE_PAMS.xlsx
-        path_pams_compare: /PATH/TO/COMPARE_PAMS.xlsx
+    compare_pams:
+        paths:
+            path_pams_base: /PATH/TO/BASE_PAMS.xlsx
+            path_pams_compare: /PATH/TO/COMPARE_PAMS.xlsx
 
-    thresholds:
-        company_id_threshold: 25
-        sectoral_production_threshold: 25
+        thresholds:
+            company_id_threshold: 25
+            sectoral_production_threshold: 25
+            
+    compare_pams_banks_eo:
+        paths:
+            path_pams: /PATH/TO/PAMS.xlsx
+            path_banks_eo: /PATH/TO/BANKS_EO.xlsx
+
+        thresholds:
+            share_rows_replicated: 0.99
+            relative_tolerance_production: 0.01
+            relative_tolerance_emission_factor: 0.01
+
 ```
 
 ## How to use the workflow

--- a/compare_pams.Rmd
+++ b/compare_pams.Rmd
@@ -34,10 +34,10 @@ knitr::knit_hooks$set(
 config <- config::get()
 
 # set configs
-base_pams_path <- config$paths$path_pams_base
-comparison_pams_path <- config$paths$path_pams_compare
-company_id_threshold <- config$thresholds$company_id_threshold
-sectoral_production_threshold <- config$thresholds$sectoral_production_threshold
+base_pams_path <- config$compare_pams$paths$path_pams_base
+comparison_pams_path <- config$compare_pams$paths$path_pams_compare
+company_id_threshold <- config$compare_pams$thresholds$company_id_threshold
+sectoral_production_threshold <- config$compare_pams$thresholds$sectoral_production_threshold
 
 library(dplyr)
 library(tibble)

--- a/compare_pams_banks_equity_ownership.Rmd
+++ b/compare_pams_banks_equity_ownership.Rmd
@@ -1,0 +1,402 @@
+---
+title: "Status Report - Comparison of PAMS and Banks Equity Ownership"
+author: "Jacob Kastl"
+date: \today
+output: 
+  html_document:
+      toc: true
+      toc_depth: 2
+      theme: flatly
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+
+knitr::knit_hooks$set(
+   error = function(x, options) {
+     paste('\n\n<div class="alert alert-danger">',
+           gsub('##', '\n', gsub('^##\ Error', '\u2716 **Error**', x)),
+           '</div>', sep = '\n')
+   },
+   warning = function(x, options) {
+     paste('\n\n<div class="alert alert-danger">',
+           gsub('##', '\n', gsub('^##\ Warning:', '\u2716 **Warning**', x)),
+           '</div>', sep = '\n')
+   },
+   message = function(x, options) {
+     paste('\n\n<div class="alert alert-success">',
+           gsub('##', '\n \u2714', x),
+           '</div>', sep = '\n')
+   }
+)
+
+
+config <- config::get()
+
+# set configs
+pams_path <- config$compare_pams_banks_eo$paths$path_pams
+banks_eo_path <- config$compare_pams_banks_eo$paths$path_banks_eo
+
+library(dplyr)
+library(tibble)
+library(readxl)
+library(tidyr)
+library(glue)
+library(pacta.data.preparation)
+```
+
+## Introduction
+
+This report checks if the PAMS and Banks Equity Ownership (EO) datasets of a common data release are consistent. For that, it compares two datasets: `pams` and `banks_eo` to ensure data consistency.
+
+In general, it is expected that the Banks Equity Ownership dataset can be recreated from the PAMS dataset. Beyond minor differences due to rounding, we would expect that it is possible to derive the Banks EO dataset from PAMS after several steps of data wrangling.
+
+We will check if the above expectation holds and gather any incosnsistencies and unexpected patterns.
+
+## Load Data
+
+The PAMS dataset of the 2023Q2 data release can use the import function `pacta.data.preparation::import_ar_advanced_company_indicators()`, which will return a tidy combination of the sheets contained in the PAMS xlsx. The Banks EO file only requires loading one sheet from an xlsx.
+
+```{r import, echo = FALSE}
+comparison_pams <- pacta.data.preparation::import_ar_advanced_company_indicators(pams_path, fix_names = TRUE)
+comparison_banks_eo <- readxl::read_xlsx(banks_eo_path, sheet = "Company Indicators - PACTA Comp")
+```
+
+## Data Overview
+
+Provide a brief overview of both datasets:
+
+``` {r summary, echo = FALSE}
+
+# Overview of pams
+cat("\nSummary of pams:\n")
+print(head(comparison_pams))
+
+# Overview of banks_eo
+cat("Summary of banks_eo:\n")
+print(head(comparison_banks_eo))
+
+```
+
+## Data Preparation
+We will now wrangle the PAMS dataset to match the Banks EO dataset as closely as possible.
+
+### Step 1: Correct columns and format
+We keep and rename the relevant columns from PAMS needed for Banks EO. And we add a column for the `ald_timestamp`, which is not given in PAMS.
+
+``` {r columns_and_format, echo = FALSE}
+ald_timestamp <- unique(comparison_banks_eo$ald_timestamp)
+if (length(ald_timestamp) > 1) {
+  stop("Cannot derive the appropriate value for `ald_timestamp` from more than one value.")
+}
+
+pams_to_banks_eo <- comparison_pams %>%
+  dplyr::select(
+    dplyr::all_of(
+      c(
+        "company_id",
+        name_company = "company_name",
+        "lei",
+        is_ultimate_owner = "is_ultimate_parent",
+        sector = "asset_sector",
+        technology = "asset_technology",
+        technology_type = "asset_technology_type",
+        plant_location = "asset_country",
+        "year",
+        "activity_unit",
+        "consolidation_method",
+        "value_type",
+        "value"
+      )
+    )
+  ) %>%
+  dplyr::filter(
+    .data$consolidation_method == "Equity Ownership"
+  ) %>%
+  dplyr::select(-"consolidation_method") %>%
+  dplyr::mutate(ald_timestamp = .env$ald_timestamp)
+
+```
+
+### Step 2: Formatting to lower case and filter appropriate values
+
+- We format relevant columns to lower case.
+- We only keep the years that are given in the Banks EO dataset.
+- We only keep power capacity, not power generation.
+- We only keep emission intensity values per unit of economic activity, not total emissions.
+
+
+``` {r format_and_filter, echo = FALSE}
+banks_eo_years <- unique(comparison_banks_eo$year)
+
+pams_to_banks_eo <- pams_to_banks_eo %>%
+  dplyr::mutate(
+    name_company = tolower(.data$name_company),
+    sector = tolower(.data$sector),
+    technology = tolower(.data$technology),
+    technology_type = tolower(.data$technology_type)
+  ) %>%
+  dplyr::filter(.data$year %in% banks_eo_years) %>% 
+  dplyr::filter(!(.data$sector == "power" & .data$activity_unit == "MWh")) %>%
+  dplyr::filter(
+    .data$value_type == "production" | (.data$value_type == "emission_intensity" & grepl("/", .data$activity_unit))
+  )
+
+```
+
+### Step 3: Wrangle production and emission factors into expected format
+
+- `production`, `production_unit`, `emission_factor`, and `emission_factor_unit` are wrangled into wide variables
+- `emission_factor` for any sector that is not evaluated using the SDA approach is set to `NA`
+
+``` {r prod_ef_wide, echo = FALSE}
+pams_to_banks_eo_production <- pams_to_banks_eo %>%
+  dplyr::filter(.data$value_type == "production") %>%
+  dplyr::select(-"value_type") %>%
+  dplyr::rename(
+    production_unit = "activity_unit",
+    production = "value"
+  )
+
+pams_to_banks_eo_emission_intensity <- pams_to_banks_eo %>%
+  dplyr::filter(.data$value_type == "emission_intensity") %>%
+  dplyr::select(-"value_type") %>%
+  dplyr::rename(
+    emission_factor_unit = "activity_unit",
+    emission_factor = "value"
+  ) %>%
+  dplyr::mutate(
+    emission_factor = dplyr::if_else(
+      .data$sector %in% c("aviation", "cement", "steel"),
+      .data$emission_factor,
+      NA_real_
+    )
+  )
+
+pams_to_banks_eo_merged <- pams_to_banks_eo_production %>%
+  dplyr::full_join(
+    pams_to_banks_eo_emission_intensity,
+    by = c("company_id", "name_company", "lei", "is_ultimate_owner", "sector", "technology", "technology_type", "plant_location", "year", "ald_timestamp")
+  )
+
+```
+
+### Step 4: Map and Filter Sectors & Technologies
+
+- Some sector and technology names need to be renamed and/or mapped to standard PACTA definitions.
+- Shipping sector is removed
+- Natural Gas Liquids is removed from Oil & Gas sector
+- Freight is removed from Aviation sector
+
+``` {r map_filter_sectors_technologies, echo = FALSE}
+
+pams_to_banks_eo_merged <- pams_to_banks_eo_merged %>%
+  dplyr::mutate(
+    sector = dplyr::case_when(
+      .data$sector == "ldv" ~ "automotive",
+      .data$sector == "oil&gas" ~ "oil and gas",
+      TRUE ~ .data$sector
+    )
+  ) %>%
+  dplyr::mutate(
+    technology = dplyr::case_when(
+      .data$sector == "coal" ~ "coal",
+      .data$technology %in% c(
+        "hybrid no-plug", "ice cng", "ice diesel", "ice e85+", "ice gasoline", "ice hydrogen", "ice propane"
+      ) ~ "ice",
+      .data$technology == "hybrid plug-in" ~ "hybrid",
+      .data$technology == "fuel cell" ~ "fuelcell",
+      .data$technology == "oil and condensate" ~ "oil",
+      TRUE ~ .data$technology
+    )
+  ) %>%
+  dplyr::filter(
+    .data$sector != "shipping",
+    !(.data$sector == "oil and gas" & .data$technology == "natural gas liquids"),
+    !(.data$sector == "aviation" & .data$technology == "freight")
+  )
+
+
+```
+
+### Step 5: Aggregate
+
+- We aggregate production and emission factors to the company-technology-country-year level.
+  - We sum up production
+  - We take a weighted mean of the emission factors, using the porduction for weighting
+
+
+```{r aggregate, echo=FALSE}
+pams_to_banks_eo_aggregated <- pams_to_banks_eo_merged %>%
+  dplyr::summarise(
+    emission_factor = stats::weighted.mean(.data$emission_factor, w = .data$production, na.rm = TRUE),
+    production = sum(.data$production, na.rm = TRUE),
+    .by = c(
+      "company_id",
+      "name_company",
+      "lei",
+      "is_ultimate_owner",
+      "sector",
+      "technology",
+      "plant_location",
+      "year",
+      "production_unit",
+      "emission_factor_unit",
+      "ald_timestamp"
+    )
+  )
+
+```
+
+### Step 6: Accomodate Banks EO particularieties
+
+The Banks EO data set has a few less than obvious traits that need to be accounted for when replicating it from PAMS:
+
+- For sectors with technology pathways, `emission_factor` is set to `NA`.
+- We remove combinations of company/technology/country that have zero production values over the entire given timeframe.
+- For combinations of company-technology-country that have missing rows in leading years, but positive `production` values in later years, we add rows for the missing leading years and set `production = 0` and `emission_factor = NA_real_`.
+
+```{r particular_wrangling, echo=FALSE}
+pams_to_banks_eo_complete <- pams_to_banks_eo_aggregated %>%
+  dplyr::mutate(
+    emission_factor = dplyr::if_else(
+      .data$sector %in% c("automotive", "coal", "hdv", "oil and gas", "power"),
+      NA_real_,
+      .data$emission_factor
+    )
+  ) %>%
+  dplyr::mutate(
+    all_zero = dplyr::if_else(sum(.data$production, na.rm = TRUE) == 0, TRUE, FALSE),
+    .by = c("company_id", "lei", "is_ultimate_owner", "sector", "technology", "plant_location", "production_unit", "emission_factor_unit", "ald_timestamp")
+  ) %>%
+  dplyr::filter(!.data$all_zero) %>%
+  dplyr::select(-"all_zero")%>%
+  tidyr::complete(
+    .data$year,
+    tidyr::nesting(
+      company_id,
+      name_company,
+      lei,
+      is_ultimate_owner,
+      sector,
+      technology,
+      plant_location,
+      production_unit,
+      emission_factor_unit,
+      ald_timestamp
+    ),
+    fill = list(
+      production = 0,
+      emission_factor = NA_real_
+    )
+  )
+
+```
+
+## Compare
+
+Finally, we compare how closely the replicated data set matches the Banks EO dataset we received.
+
+We compare across the following dimensions:
+
+- How many rows are successfully replicated?
+- How many rows are given in the PAMS-based replica, but not in the Banks EO dataset?
+- How many rows are given in the Banks EO dataset, but not in the PAMS-based replica?
+- What are the patterns of those rows that were not successfully replicated?
+- Are the production and emission_factor values inequal between the successfully replicated rows and the Banks EO dataset?
+- If not, how far off are they?
+
+Note: In assessing the differences, we ignore the differences in names for now, as the formatting steps are not 100% clear beyond changing the names to lower case. We thus only focus on `company_id` for comparison for now.
+
+```{r successfully_replicated, echo=FALSE}
+common_data <- comparison_banks_eo %>%
+  dplyr::inner_join(
+    pams_to_banks_eo_complete,
+    by = c(
+      "company_id", "lei", "is_ultimate_owner", "sector", "technology", "plant_location", "year", "production_unit", "emission_factor_unit", "ald_timestamp"
+    )
+  ) %>%
+  dplyr::mutate(
+    prod_diff = (production.x - production.y) / production.x,
+    ef_diff = (emission_factor.x - emission_factor.y) / emission_factor.x
+  )
+
+share_rows_replicated <- nrow(common_data) / nrow(comparison_banks_eo)
+
+```
+
+We calculate the percentage difference in production and emission_factor values between the two datasets. We expect that percent difference to be zero or very close to zero (as there are sometimes rounding errors).
+
+```{r plots_successfully_replicated, echo=FALSE}
+common_data %>%
+  ggplot2::ggplot(ggplot2::aes(x = prod_diff, y = production.x)) +
+  ggplot2::geom_point() +
+  ggplot2::facet_wrap(~ sector, scales = "free_y") +
+  ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust=1))
+
+common_data %>%
+  ggplot2::ggplot(ggplot2::aes(x = ef_diff, y = emission_factor.x)) +
+  ggplot2::geom_point() +
+  ggplot2::facet_wrap(~ sector, scales = "free_y") +
+  ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust=1))
+
+
+```
+
+In total, `r round(share_rows_replicated * 100, 3)` % of the rows in the banks data set have been successfully replicated.
+
+We now compare the sectoral production totals and weighted average emission_factor from the Banks EO and the PAMS-based replica.
+
+```{r compare_total}
+
+min_year <- min(comparison_banks_eo$year)
+max_year <- max(comparison_banks_eo$year)
+
+totals_banks_eo <- comparison_banks_eo %>% 
+  dplyr::summarise(
+    emission_factor = stats::weighted.mean(.data$emission_factor, w = .data$production, na.rm = TRUE),
+    production = sum(.data$production, na.rm = TRUE),
+    .by = c("year", "sector")
+  ) %>% 
+  dplyr::filter(.data$year %in% c(min_year, max_year))
+
+totals_pams_replica <- pams_to_banks_eo_complete %>% 
+  dplyr::summarise(
+    emission_factor = stats::weighted.mean(.data$emission_factor, w = .data$production, na.rm = TRUE),
+    production = sum(.data$production, na.rm = TRUE),
+    .by = c("year", "sector")
+  ) %>% 
+  dplyr::filter(.data$year %in% c(min_year, max_year))
+
+sector_totals <- totals_banks_eo %>% 
+  dplyr::inner_join(
+    totals_pams_replica,
+    by = c("sector", "year"),
+    suffix = c("_banks", "_replica")
+  ) %>% 
+  dplyr::mutate(
+    emission_factor_banks = dplyr::if_else(is.nan(.data$emission_factor_banks), NA_real_, .data$emission_factor_banks),
+    emission_factor_replica = dplyr::if_else(is.nan(.data$emission_factor_replica), NA_real_, .data$emission_factor_replica)
+  ) %>% 
+  dplyr::mutate(
+    prod_equal = dplyr::if_else(.data$production_banks == .data$production_replica, TRUE, FALSE),
+    ef_equal = dplyr::if_else(.data$emission_factor_banks == .data$emission_factor_replica, TRUE, FALSE)
+  ) %>% 
+  dplyr::relocate("sector", "year", "production_banks", "production_replica", "prod_equal", "emission_factor_banks", "emission_factor_replica", "ef_equal")
+
+DT::datatable(sector_totals)
+
+```
+
+
+
+## Conclusion
+
+If all indicators in the table above are `TRUE`, the data set passes the consistency check. 
+
+If some are not `TRUE`, please check:
+
+- are there `NA` values, because of expected missing values? (e.g. `emission_factor` in technology pathway sectors)
+- are the of the `FALSE` indicators likely due to rounding? (i.e. the actual summary values seem almost identical and the plots above indicate extremely low differences)
+
+If the answer to either of the above points is "no", further investigation is needed.

--- a/compare_pams_banks_equity_ownership.Rmd
+++ b/compare_pams_banks_equity_ownership.Rmd
@@ -37,6 +37,10 @@ config <- config::get()
 pams_path <- config$compare_pams_banks_eo$paths$path_pams
 banks_eo_path <- config$compare_pams_banks_eo$paths$path_banks_eo
 
+threshold_rows_replicated <- config$compare_pams_banks_eo$thresholds$share_rows_replicated
+relative_tolerance_production <- config$compare_pams_banks_eo$thresholds$relative_tolerance_production
+relative_tolerance_emission_factor <- config$compare_pams_banks_eo$thresholds$relative_tolerance_emission_factor
+
 library(dplyr)
 library(tibble)
 library(readxl)
@@ -66,7 +70,7 @@ comparison_banks_eo <- readxl::read_xlsx(banks_eo_path, sheet = "Company Indicat
 
 Provide a brief overview of both datasets:
 
-``` {r summary, echo = FALSE}
+``` {r summary, echo = FALSE, include=FALSE}
 
 # Overview of pams
 cat("\nSummary of pams:\n")
@@ -84,7 +88,7 @@ We will now wrangle the PAMS dataset to match the Banks EO dataset as closely as
 ### Step 1: Correct columns and format
 We keep and rename the relevant columns from PAMS needed for Banks EO. And we add a column for the `ald_timestamp`, which is not given in PAMS.
 
-``` {r columns_and_format, echo = FALSE}
+``` {r columns_and_format, echo = FALSE, include=FALSE}
 ald_timestamp <- unique(comparison_banks_eo$ald_timestamp)
 if (length(ald_timestamp) > 1) {
   stop("Cannot derive the appropriate value for `ald_timestamp` from more than one value.")
@@ -114,7 +118,12 @@ pams_to_banks_eo <- comparison_pams %>%
     .data$consolidation_method == "Equity Ownership"
   ) %>%
   dplyr::select(-"consolidation_method") %>%
-  dplyr::mutate(ald_timestamp = .env$ald_timestamp)
+  dplyr::mutate(ald_timestamp = .env$ald_timestamp) %>% 
+  dplyr::mutate(
+    lei = as.character(.data$lei),
+    plant_location = as.character(.data$plant_location),
+    activity_unit = as.character(.data$activity_unit)
+  )
 
 ```
 
@@ -126,7 +135,7 @@ pams_to_banks_eo <- comparison_pams %>%
 - We only keep emission intensity values per unit of economic activity, not total emissions.
 
 
-``` {r format_and_filter, echo = FALSE}
+``` {r format_and_filter, echo = FALSE, include=FALSE}
 banks_eo_years <- unique(comparison_banks_eo$year)
 
 pams_to_banks_eo <- pams_to_banks_eo %>%
@@ -136,7 +145,7 @@ pams_to_banks_eo <- pams_to_banks_eo %>%
     technology = tolower(.data$technology),
     technology_type = tolower(.data$technology_type)
   ) %>%
-  dplyr::filter(.data$year %in% banks_eo_years) %>% 
+  dplyr::filter(.data$year %in% .env$banks_eo_years) %>% 
   dplyr::filter(!(.data$sector == "power" & .data$activity_unit == "MWh")) %>%
   dplyr::filter(
     .data$value_type == "production" | (.data$value_type == "emission_intensity" & grepl("/", .data$activity_unit))
@@ -149,7 +158,7 @@ pams_to_banks_eo <- pams_to_banks_eo %>%
 - `production`, `production_unit`, `emission_factor`, and `emission_factor_unit` are wrangled into wide variables
 - `emission_factor` for any sector that is not evaluated using the SDA approach is set to `NA`
 
-``` {r prod_ef_wide, echo = FALSE}
+``` {r prod_ef_wide, echo = FALSE, include=FALSE}
 pams_to_banks_eo_production <- pams_to_banks_eo %>%
   dplyr::filter(.data$value_type == "production") %>%
   dplyr::select(-"value_type") %>%
@@ -188,7 +197,7 @@ pams_to_banks_eo_merged <- pams_to_banks_eo_production %>%
 - Natural Gas Liquids is removed from Oil & Gas sector
 - Freight is removed from Aviation sector
 
-``` {r map_filter_sectors_technologies, echo = FALSE}
+``` {r map_filter_sectors_technologies, echo = FALSE, include=FALSE}
 
 pams_to_banks_eo_merged <- pams_to_banks_eo_merged %>%
   dplyr::mutate(
@@ -202,10 +211,10 @@ pams_to_banks_eo_merged <- pams_to_banks_eo_merged %>%
     technology = dplyr::case_when(
       .data$sector == "coal" ~ "coal",
       .data$technology %in% c(
-        "hybrid no-plug", "ice cng", "ice diesel", "ice e85+", "ice gasoline", "ice hydrogen", "ice propane"
+        "hybrid no-plug", "ice cng", "ice diesel", "ice e85+", "ice gasoline", "ice propane"
       ) ~ "ice",
       .data$technology == "hybrid plug-in" ~ "hybrid",
-      .data$technology == "fuel cell" ~ "fuelcell",
+      .data$technology %in% c("fuel cell", "ice hydrogen") ~ "fuelcell",
       .data$technology == "oil and condensate" ~ "oil",
       TRUE ~ .data$technology
     )
@@ -226,7 +235,7 @@ pams_to_banks_eo_merged <- pams_to_banks_eo_merged %>%
   - We take a weighted mean of the emission factors, using the porduction for weighting
 
 
-```{r aggregate, echo=FALSE}
+```{r aggregate, echo=FALSE, include=FALSE}
 pams_to_banks_eo_aggregated <- pams_to_banks_eo_merged %>%
   dplyr::summarise(
     emission_factor = stats::weighted.mean(.data$emission_factor, w = .data$production, na.rm = TRUE),
@@ -256,7 +265,7 @@ The Banks EO data set has a few less than obvious traits that need to be account
 - We remove combinations of company/technology/country that have zero production values over the entire given timeframe.
 - For combinations of company-technology-country that have missing rows in leading years, but positive `production` values in later years, we add rows for the missing leading years and set `production = 0` and `emission_factor = NA_real_`.
 
-```{r particular_wrangling, echo=FALSE}
+```{r particular_wrangling, echo=FALSE, include=FALSE}
 pams_to_banks_eo_complete <- pams_to_banks_eo_aggregated %>%
   dplyr::mutate(
     emission_factor = dplyr::if_else(
@@ -303,51 +312,119 @@ We compare across the following dimensions:
 - How many rows are given in the PAMS-based replica, but not in the Banks EO dataset?
 - How many rows are given in the Banks EO dataset, but not in the PAMS-based replica?
 - What are the patterns of those rows that were not successfully replicated?
-- Are the production and emission_factor values inequal between the successfully replicated rows and the Banks EO dataset?
+- Are the production and emission_factor values equal between the successfully replicated rows and the Banks EO dataset?
 - If not, how far off are they?
 
 Note: In assessing the differences, we ignore the differences in names for now, as the formatting steps are not 100% clear beyond changing the names to lower case. We thus only focus on `company_id` for comparison for now.
 
-```{r successfully_replicated, echo=FALSE}
+### Expectation 1: Share of rows successfully replicated
+
+We calculate the percentage difference in production and emission_factor values between the two datasets. We expect that percent difference to be zero or very close to zero (as there are sometimes rounding errors).
+
+
+```{r successfully_replicated, echo=FALSE, include=FALSE}
 common_data <- comparison_banks_eo %>%
   dplyr::inner_join(
     pams_to_banks_eo_complete,
     by = c(
       "company_id", "lei", "is_ultimate_owner", "sector", "technology", "plant_location", "year", "production_unit", "emission_factor_unit", "ald_timestamp"
-    )
+    ),
+    suffix = c("_banks", "_replica")
   ) %>%
   dplyr::mutate(
-    prod_diff = (production.x - production.y) / production.x,
-    ef_diff = (emission_factor.x - emission_factor.y) / emission_factor.x
+    prod_diff = (production_replica - production_banks) / production_banks,
+    ef_diff = (emission_factor_replica - emission_factor_banks) / emission_factor_banks
   )
 
 share_rows_replicated <- nrow(common_data) / nrow(comparison_banks_eo)
 
-```
-
-We calculate the percentage difference in production and emission_factor values between the two datasets. We expect that percent difference to be zero or very close to zero (as there are sometimes rounding errors).
-
-```{r plots_successfully_replicated, echo=FALSE}
-common_data %>%
-  ggplot2::ggplot(ggplot2::aes(x = prod_diff, y = production.x)) +
-  ggplot2::geom_point() +
-  ggplot2::facet_wrap(~ sector, scales = "free_y") +
-  ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust=1))
-
-common_data %>%
-  ggplot2::ggplot(ggplot2::aes(x = ef_diff, y = emission_factor.x)) +
-  ggplot2::geom_point() +
-  ggplot2::facet_wrap(~ sector, scales = "free_y") +
-  ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust=1))
-
+if (share_rows_replicated < threshold_rows_replicated) {
+    warning(glue::glue("The share of rows from the Banks EO dataset that was successfully replicated, is {round(share_rows_replicated * 100, 3)}%, which is less than the expected minimum threshold of {threshold_rows_replicated * 100}%."))
+}
+  
+if (share_rows_replicated >= threshold_rows_replicated) {
+  message(glue::glue("The share of rows from the Banks EO dataset that was successfully replicated, is {round(share_rows_replicated * 100, 3)}%."))
+}
 
 ```
 
-In total, `r round(share_rows_replicated * 100, 3)` % of the rows in the banks data set have been successfully replicated.
+### Expectation 2: Remaining differences due to rounding
+
+Remaining numeric differences in successfully replicated rows for production and emission_factor values are due to rounding, if the replicated values
+
+- for `production` are within `r relative_tolerance_production * 100`% of the original `production` values
+- for `emission_factor` are within `r relative_tolerance_emission_factor * 100`% of the original `emission_factor` values
+
+```{r replicated_rounding, echo=FALSE, include=FALSE}
+common_data_rounding <- common_data %>%
+  dplyr::mutate(
+    match_prod = dplyr::if_else(abs(.data$prod_diff) <= relative_tolerance_production, TRUE, FALSE),
+    match_ef = dplyr::if_else(abs(.data$ef_diff) <= relative_tolerance_emission_factor, TRUE, FALSE)
+  )
+
+common_data_summary <- common_data_rounding %>% 
+  dplyr::summarise(
+    sum_rounding_prod = sum(.data$match_prod, na.rm = TRUE),
+    sum_rounding_ef = sum(.data$match_ef, na.rm = TRUE)
+  )
+
+n_prod <- common_data %>% dplyr::filter(!is.na(.data$prod_diff)) %>% nrow()
+n_ef <- common_data %>% dplyr::filter(!is.na(.data$ef_diff)) %>% nrow()
+
+share_rounding_prod <- common_data_summary$sum_rounding_prod / n_prod
+share_rounding_ef <- common_data_summary$sum_rounding_ef / n_ef
+
+common_data_rounding_prod_f <- common_data_rounding %>% 
+  dplyr::filter(!.data$match_prod)
+
+common_data_rounding_ef_f <- common_data_rounding %>% 
+  dplyr::filter(!.data$match_ef)
+
+if (share_rounding_prod < 1) {
+    warning(glue::glue("There are {n_prod - common_data_summary$sum_rounding_prod} replicated rows that have `production` differences larger than the accepted rounding threshold of {relative_tolerance_production * 100}%."))
+  
+  DT::datatable(common_data_rounding_prod_f)
+}
+
+if (share_rounding_prod == 1) {
+  message(glue::glue("All replicated rows have `production` values no no further off from the original value than the accepted rounding threshold of {relative_tolerance_production * 100}%."))
+}
+
+common_data %>%
+  # remove NAs, which can be created when 0 or NA production values are compared.
+  dplyr::filter(!is.na(.data$prod_diff)) %>% 
+  ggplot2::ggplot(ggplot2::aes(x = prod_diff, y = production_banks)) +
+  ggplot2::geom_point() +
+  ggplot2::facet_wrap(~ sector, scales = "free") +
+  ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust=1))
+
+
+if (share_rounding_ef < 1) {
+    warning(glue::glue("There are {n_ef - common_data_summary$sum_rounding_ef} replicated rows that have `emission_factor` differences larger than the accepted rounding threshold of {relative_tolerance_emission_factor * 100}%."))
+  
+  DT::datatable(common_data_rounding_ef_f)
+}
+
+if (share_rounding_ef == 1) {
+  message(glue::glue("All replicated rows have `emission_factor` values no further off from the original value than the accepted rounding threshold of {relative_tolerance_emission_factor * 100}%."))
+} 
+
+common_data %>%
+  # remove NaNs, which can be created when NA emission_factor values are compared.
+  dplyr::filter(!is.na(.data$ef_diff)) %>% 
+  ggplot2::ggplot(ggplot2::aes(x = ef_diff, y = emission_factor_banks)) +
+  ggplot2::geom_point() +
+  ggplot2::facet_wrap(~ sector, scales = "free") +
+  ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust=1))
+
+
+```
+
+### Expectation 3: Sector totals are equal
 
 We now compare the sectoral production totals and weighted average emission_factor from the Banks EO and the PAMS-based replica.
 
-```{r compare_total}
+```{r compare_total, include=FALSE}
 
 min_year <- min(comparison_banks_eo$year)
 max_year <- max(comparison_banks_eo$year)
@@ -357,16 +434,16 @@ totals_banks_eo <- comparison_banks_eo %>%
     emission_factor = stats::weighted.mean(.data$emission_factor, w = .data$production, na.rm = TRUE),
     production = sum(.data$production, na.rm = TRUE),
     .by = c("year", "sector")
-  ) %>% 
-  dplyr::filter(.data$year %in% c(min_year, max_year))
+  ) #%>% 
+  # dplyr::filter(.data$year %in% c(min_year, max_year))
 
 totals_pams_replica <- pams_to_banks_eo_complete %>% 
   dplyr::summarise(
     emission_factor = stats::weighted.mean(.data$emission_factor, w = .data$production, na.rm = TRUE),
     production = sum(.data$production, na.rm = TRUE),
     .by = c("year", "sector")
-  ) %>% 
-  dplyr::filter(.data$year %in% c(min_year, max_year))
+  ) #%>% 
+  # dplyr::filter(.data$year %in% c(min_year, max_year))
 
 sector_totals <- totals_banks_eo %>% 
   dplyr::inner_join(
@@ -379,24 +456,76 @@ sector_totals <- totals_banks_eo %>%
     emission_factor_replica = dplyr::if_else(is.nan(.data$emission_factor_replica), NA_real_, .data$emission_factor_replica)
   ) %>% 
   dplyr::mutate(
+    production_banks = round(.data$production_banks),
+    production_replica = round(.data$production_replica),
+    emission_factor_banks = signif(.data$emission_factor_banks),
+    emission_factor_replica = signif(.data$emission_factor_replica)
+  ) %>% 
+  dplyr::summarise(
+    emission_factor_banks = stats::weighted.mean(.data$emission_factor_banks, w = .data$production_banks, na.rm = TRUE),
+    emission_factor_replica = stats::weighted.mean(.data$emission_factor_replica, w = .data$production_replica, na.rm = TRUE),
+    production_banks = sum(.data$production_banks, na.rm = TRUE),
+    production_replica = sum(.data$production_replica, na.rm = TRUE),
+    .by = c("sector")
+  ) %>% 
+  dplyr::mutate(
     prod_equal = dplyr::if_else(.data$production_banks == .data$production_replica, TRUE, FALSE),
     ef_equal = dplyr::if_else(.data$emission_factor_banks == .data$emission_factor_replica, TRUE, FALSE)
   ) %>% 
-  dplyr::relocate("sector", "year", "production_banks", "production_replica", "prod_equal", "emission_factor_banks", "emission_factor_replica", "ef_equal")
+  dplyr::relocate("sector", "production_banks", "production_replica", "prod_equal", "emission_factor_banks", "emission_factor_replica", "ef_equal")
+
+for (i in unique(totals_banks_eo$sector)) {
+  sector_totals_i <- sector_totals %>% 
+    filter(
+      .data$sector == i
+    ) %>% 
+    distinct(.data$prod_equal) %>% 
+    pull()
+  
+  if (is.na(sector_totals_i)) {
+    next()
+  } else if (!sector_totals_i) {
+    warning(glue::glue("In the {i} Sector, there are differences in total production values between the Banks EO and the PAMS replica data sets.}"))
+  } else if (sector_totals_i) {
+    message(glue::glue("In the {i} Sector, total production values are identical between the Banks EO and the PAMS replica data sets."))
+  }
+}
+
+for (i in unique(totals_banks_eo$sector)) {
+  sector_totals_i <- sector_totals %>% 
+    filter(
+      .data$sector == i
+    ) %>% 
+    distinct(.data$ef_equal) %>% 
+    pull()
+  
+  if (is.na(sector_totals_i)) {
+    next()
+  } else if (!sector_totals_i) {
+    warning(glue::glue("In the {i} Sector, there are differences in weighted mean `emission_factor` values between the Banks EO and the PAMS replica data sets.}"))
+  } else if (sector_totals_i) {
+    message(glue::glue("In the {i} Sector, weighted mean `emission_factor` values are identical between the Banks EO and the PAMS replica data sets."))
+  }
+}
+
 
 DT::datatable(sector_totals)
-
 ```
 
+Below, we see a table of cases that shows rows that could not be recreated from PAMS, although they are given in Banks EO. This may explain to some degree the differences between production matches in the replicated data. In any case, these differences may need explanation/investigation from AI.
 
+```{r distinct_data_banks, echo=FALSE, include=FALSE}
+distinct_data_banks <- comparison_banks_eo %>%
+  dplyr::anti_join(
+    pams_to_banks_eo_complete,
+    by = c("company_id", "lei", "is_ultimate_owner", "sector", "technology", "plant_location", "year", "production_unit", "emission_factor_unit", "ald_timestamp")
+  )
+
+DT::datatable(distinct_data_banks)
+```
 
 ## Conclusion
 
-If all indicators in the table above are `TRUE`, the data set passes the consistency check. 
+If all indicators above are green, the data set passes the consistency check. 
 
-If some are not `TRUE`, please check:
-
-- are there `NA` values, because of expected missing values? (e.g. `emission_factor` in technology pathway sectors)
-- are the of the `FALSE` indicators likely due to rounding? (i.e. the actual summary values seem almost identical and the plots above indicate extremely low differences)
-
-If the answer to either of the above points is "no", further investigation is needed.
+If some are red and/or differences are listed, further investigation is needed.

--- a/config.yml
+++ b/config.yml
@@ -2,8 +2,8 @@ default:
 
     compare_pams:
         paths:
-          path_pams_base: /PATH/TO/BASE_PAMS.xlsx
-          path_pams_compare: /PATH/TO/COMPARE_PAMS.xlsx
+            path_pams_base: /PATH/TO/BASE_PAMS.xlsx
+            path_pams_compare: /PATH/TO/COMPARE_PAMS.xlsx
 
         thresholds:
             company_id_threshold: 25

--- a/config.yml
+++ b/config.yml
@@ -1,9 +1,17 @@
 default:
 
-    paths:
-        path_pams_base: /PATH/TO/BASE_PAMS.xlsx
-        path_pams_compare: /PATH/TO/COMPARE_PAMS.xlsx
+    compare_pams:
+        paths:
+          path_pams_base: /PATH/TO/BASE_PAMS.xlsx
+          path_pams_compare: /PATH/TO/COMPARE_PAMS.xlsx
 
-    thresholds:
-        company_id_threshold: 25
-        sectoral_production_threshold: 25
+        thresholds:
+            company_id_threshold: 25
+            sectoral_production_threshold: 25
+
+    compare_pams_banks_eo:
+        paths:
+            # path_pams: /PATH/TO/PAMS.xlsx
+            # path_banks_eo: /PATH/TO/BANKS_EO.xlsx
+          path_pams: /Users/jacobkastl/Downloads/2023-08-14_AI_RMI_2023Q2/2023-08-14_AI_2023Q2_RMI-Advanced-Indicators.xlsx
+          path_banks_eo: /Users/jacobkastl/Downloads/2023-08-14_AI_RMI_2023Q2/2023-08-14_AI_2023Q2_PACTA for Banks Free dataset_EO.xlsx

--- a/config.yml
+++ b/config.yml
@@ -2,8 +2,10 @@ default:
 
     compare_pams:
         paths:
-          path_pams_base: /PATH/TO/BASE_PAMS.xlsx
-          path_pams_compare: /PATH/TO/COMPARE_PAMS.xlsx
+          # path_pams_base: /PATH/TO/BASE_PAMS.xlsx
+          # path_pams_compare: /PATH/TO/COMPARE_PAMS.xlsx
+          path_pams_base: /Users/jacobkastl/Downloads/2022Q4/2023-02-15_AI_RMI_Advanced Company Indicators_2022Q4.xlsx
+          path_pams_compare: /Users/jacobkastl/Downloads/2023-08-14_AI_RMI_2023Q2/2023-08-14_AI_2023Q2_RMI-Advanced-Indicators.xlsx
 
         thresholds:
             company_id_threshold: 25
@@ -15,3 +17,8 @@ default:
             # path_banks_eo: /PATH/TO/BANKS_EO.xlsx
           path_pams: /Users/jacobkastl/Downloads/2023-08-14_AI_RMI_2023Q2/2023-08-14_AI_2023Q2_RMI-Advanced-Indicators.xlsx
           path_banks_eo: /Users/jacobkastl/Downloads/2023-08-14_AI_RMI_2023Q2/2023-08-14_AI_2023Q2_PACTA for Banks Free dataset_EO.xlsx
+
+        thresholds:
+            share_rows_replicated: 0.99
+            relative_tolerance_production: 0.01
+            relative_tolerance_emission_factor: 0.01

--- a/config.yml
+++ b/config.yml
@@ -2,10 +2,8 @@ default:
 
     compare_pams:
         paths:
-          # path_pams_base: /PATH/TO/BASE_PAMS.xlsx
-          # path_pams_compare: /PATH/TO/COMPARE_PAMS.xlsx
-          path_pams_base: /Users/jacobkastl/Downloads/2022Q4/2023-02-15_AI_RMI_Advanced Company Indicators_2022Q4.xlsx
-          path_pams_compare: /Users/jacobkastl/Downloads/2023-08-14_AI_RMI_2023Q2/2023-08-14_AI_2023Q2_RMI-Advanced-Indicators.xlsx
+          path_pams_base: /PATH/TO/BASE_PAMS.xlsx
+          path_pams_compare: /PATH/TO/COMPARE_PAMS.xlsx
 
         thresholds:
             company_id_threshold: 25
@@ -13,10 +11,8 @@ default:
 
     compare_pams_banks_eo:
         paths:
-            # path_pams: /PATH/TO/PAMS.xlsx
-            # path_banks_eo: /PATH/TO/BANKS_EO.xlsx
-          path_pams: /Users/jacobkastl/Downloads/2023-08-14_AI_RMI_2023Q2/2023-08-14_AI_2023Q2_RMI-Advanced-Indicators.xlsx
-          path_banks_eo: /Users/jacobkastl/Downloads/2023-08-14_AI_RMI_2023Q2/2023-08-14_AI_2023Q2_PACTA for Banks Free dataset_EO.xlsx
+            path_pams: /PATH/TO/PAMS.xlsx
+            path_banks_eo: /PATH/TO/BANKS_EO.xlsx
 
         thresholds:
             share_rows_replicated: 0.99


### PR DESCRIPTION
closes ADO: https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_workitems/edit/7435
relates to ADO: https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_workitems/edit/7448

This PR:
- adds a Rmd script that checks the consistency between a PAMS data set and a Banks equity ownership data set from the same data release.
- It replicates the Banks data set based on the PAMS data set and checks that the resulting data has the same structure and meets the same `production` and `emission_factor` numbers as the banks data set.
- Some wrangling and mapping is required to match the particular formatting conventions of the banks data set.